### PR TITLE
use the version bumped sentinal to cleanup runtime library conflicts

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -5,7 +5,7 @@ object RaikuBuild extends Build {
   override lazy val settings = super.settings ++
     Seq(
       name := "raiku",
-      version := "0.7.0-M1",
+      version := "0.7.0-M2",
       organization := "nl.gideondk",
       scalaVersion := "2.11.1",
       publishTo := Some(Resolver.file("file", new File("/Users/gideondk/Development/gideondk-mvn-repo"))),
@@ -23,11 +23,10 @@ object RaikuBuild extends Build {
                   "spray repo" at "http://repo.spray.io"))
 
   val appDependencies = Seq(
-      "com.google.protobuf" % "protobuf-java" % "2.4.1",
       "io.spray" %%  "spray-json" % "1.2.6",
       "net.sandrogrzicic" %% "scalabuff-runtime" % "1.3.8",
       
-      "nl.gideondk" %% "sentinel" % "0.7.5",
+      "nl.gideondk" %% "sentinel" % "0.7.5.1",
       "org.scalatest" %% "scalatest" % "2.2.0" % "test"
   )
 


### PR DESCRIPTION
update to use my dependency cleaned version of sentinal. The only real thing here is that so if you accept that request but choose a different version you can just go ahead and close this.
